### PR TITLE
Update the OpenTelemetry SDK version to 1.38.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version '1.0'
 ext {
     versions = [
         // this line is managed by .github/scripts/update-sdk-version.sh
-        opentelemetrySdk           : "1.37.0",
+        opentelemetrySdk           : "1.38.0",
 
         // these lines are managed by .github/scripts/update-version.sh
         opentelemetryJavaagent     : "1.32.0-SNAPSHOT",


### PR DESCRIPTION
Update the OpenTelemetry SDK version to `1.38.0`.