### PR TITLE
Update the OpenTelemetry otel extension version to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ version '1.0'
 ext {
     versions = [
         // this line is managed by .github/scripts/update-sdk-version.sh
-        opentelemetrySdk           : "1.41.0",
+        opentelemetrySdk           : "2.6.0",
 
         // these lines are managed by .github/scripts/update-version.sh
         opentelemetryJavaagent     : "1.32.0",


### PR DESCRIPTION
Update the OpenTelemetry otel extension version to `2.6.0`.