### PR TITLE
Update the OpenTelemetry otel extension version to 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id "com.diffplug.spotless" version "6.22.0"
 
     // https://plugins.gradle.org/plugin/io.opentelemetry.instrumentation.muzzle-generation
-    id "io.opentelemetry.instrumentation.muzzle-generation" version "1.32.0-alpha"
-    id "io.opentelemetry.instrumentation.muzzle-check" version "1.32.0-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-generation" version "2.6.0-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-check" version "2.6.0-alpha"
 }
 
 group 'io.daocloud.otel.java.extension.nacos'
@@ -27,8 +27,8 @@ ext {
         opentelemetrySdk           : "1.41.0",
 
         // these lines are managed by .github/scripts/update-version.sh
-        opentelemetryJavaagent     : "1.32.0",
-        opentelemetryJavaagentAlpha: "1.32.0-alpha",
+        opentelemetryJavaagent     : "2.6.0",
+        opentelemetryJavaagentAlpha: "2.6.0-alpha",
 
         junit                      : "5.10.0"
     ]


### PR DESCRIPTION
Update the OpenTelemetry otel extension version to `2.6.0`.