### PR TITLE
Update the OpenTelemetry SDK version to 1.46.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ version '1.0'
 ext {
     versions = [
         // this line is managed by .github/scripts/update-sdk-version.sh
-        opentelemetrySdk           : "1.45.0",
+        opentelemetrySdk           : "1.46.0",
 
         // these lines are managed by .github/scripts/update-version.sh
         opentelemetryJavaagent     : "2.11.0",


### PR DESCRIPTION
Update the OpenTelemetry SDK version to `1.46.0`.