### PR TITLE
Update the OpenTelemetry otel extension version to 2.13.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id "com.diffplug.spotless" version "6.25.0"
 
     // https://plugins.gradle.org/plugin/io.opentelemetry.instrumentation.muzzle-generation
-    id "io.opentelemetry.instrumentation.muzzle-generation" version "2.13.1-alpha"
-    id "io.opentelemetry.instrumentation.muzzle-check" version "2.13.1-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-generation" version "2.13.3-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-check" version "2.13.3-alpha"
 }
 
 group 'io.daocloud.otel.java.extension.nacos'
@@ -27,8 +27,8 @@ ext {
         opentelemetrySdk           : "1.47.0",
 
         // these lines are managed by .github/scripts/update-version.sh
-        opentelemetryJavaagent     : "2.13.1",
-        opentelemetryJavaagentAlpha: "2.13.1-alpha",
+        opentelemetryJavaagent     : "2.13.3",
+        opentelemetryJavaagentAlpha: "2.13.3-alpha",
 
         junit                      : "5.11.4"
     ]


### PR DESCRIPTION
Update the OpenTelemetry otel extension version to `2.13.3`. \n # ⚠️Changelog: \n View on GitHub: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.13.3 