### PR TITLE
Update the OpenTelemetry otel extension version to 2.27.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ plugins {
     id "com.diffplug.spotless" version "7.2.1"
 
     // https://plugins.gradle.org/plugin/io.opentelemetry.instrumentation.muzzle-generation
-    id "io.opentelemetry.instrumentation.muzzle-generation" version "2.26.0-alpha"
-    id "io.opentelemetry.instrumentation.muzzle-check" version "2.26.0-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-generation" version "2.27.0-alpha"
+    id "io.opentelemetry.instrumentation.muzzle-check" version "2.27.0-alpha"
 }
 
 group 'io.daocloud.otel.java.extension'
@@ -27,8 +27,8 @@ ext {
         opentelemetrySdk           : "1.60.1",
 
         // these lines are managed by .github/scripts/update-version.sh
-        opentelemetryJavaagent     : "2.26.0",
-        opentelemetryJavaagentAlpha: "2.26.0-alpha",
+        opentelemetryJavaagent     : "2.27.0",
+        opentelemetryJavaagentAlpha: "2.27.0-alpha",
 
         junit                      : "5.11.4"
     ]


### PR DESCRIPTION
Update the OpenTelemetry otel extension version to `2.27.0`. \n # ⚠️Changelog: \n View on GitHub: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.27.0 